### PR TITLE
updated Google Analytics tracking code to enable cross-domain tracking

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -18,7 +18,7 @@ navbar:
     - icon: fa fa-rss
       href: index.xml
 base_url: https://blogs.rstudio.com/tensorflow/
-google_analytics: "UA-102325748-2"
+google_analytics: "UA-20375833-3"
 favicon: images/favicon.png
 collections:
   posts:


### PR DESCRIPTION
Hi @javierluraschi --

I swapped out the GA tracking code so that we can track the AI Blog as part of RStudio's other domains.  Thanks so much for your help!

Sarah