### PR TITLE
fix install instructions to match collab notebook

### DIFF
--- a/_posts/2020-09-29-introducing-torch-for-r/introducing_torch_for_R.Rmd
+++ b/_posts/2020-09-29-introducing-torch-for-r/introducing_torch_for_R.Rmd
@@ -74,7 +74,7 @@ Whereas `torch` is where tensors, network modules, and generic data loading func
 As of this writing, PyTorch has dedicated libraries for three domain areas: vision, text, and audio. In R, we plan to proceed analogously -- "plan", because `torchtext` and `torchaudio` are yet to be created. Right now, `torchvision` is all we need:
 
 ```{r}
-install.packages("torchvision")
+devtools::install_github("mlverse/torchvision")
 ```
 
 And we're ready to load the data.


### PR DESCRIPTION
It seems that `torchvision` is not on CRAN, so following the post instructions is not reproducible.