### PR TITLE
update pandoc version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   # Version of pandoc to be used for rendering blog posts
-  AI_BLOG_PANDOC_VERSION: '2.10.1'
+  AI_BLOG_PANDOC_VERSION: '2.13'
   # R packages that are required for rendering blog posts
   AI_BLOG_REQUIRED_PKGS: 'rmarkdown,distill,reticulate,dplyr,data.table,DT'
 


### PR DESCRIPTION
We should attempt to update the version of pandoc used to render RStudio AI blog posts every once in a while. If there is no rendering issue while switching to the latest stable version of pandoc, then we should make the switch.

Signed-off-by: Yitao Li <yitao@rstudio.com>