### PR TITLE
Update {keras} -> {keras3} transition plans

### DIFF
--- a/_posts/2024-05-21-keras3/introducing-keras3.Rmd
+++ b/_posts/2024-05-21-keras3/introducing-keras3.Rmd
@@ -277,7 +277,7 @@ for example usage.
 
 ### Migrating from `{keras}` to `{keras3}`
 
-`{keras3}` is ultimately a preview of the future `{keras}` package.
+`{keras3}` supersedes the `{keras}` package.
 
 If you're writing new code today, you can start using `{keras3}` right
 away.
@@ -297,14 +297,8 @@ hesitate to ask on <https://github.com/rstudio/keras/issues> or
 The `{keras}` and `{keras3}` packages will coexist while the community
 transitions. During the transition, `{keras}` will continue to receive
 patch updates for compatibility with Keras v2, which continues to be
-published to PyPi under the package name `tf-keras`.
-
-`{keras3}` is intended as a transition package name. In a future update,
-the `{keras}` package will begin emitting a package startup message,
-announcing a deprecation period. After a notice period in the `{keras}`
-package, `{keras3}` will be renamed to `{keras}`. At that time `{keras}`
-(v2) will no longer be supported, and `{keras3}` will be an alias for
-`{keras}`.
+published to PyPi under the package name `tf-keras`. After `tf-keras` is
+no longer maintained, the `{keras}` package will be archived.
 
 ## Summary
 


### PR DESCRIPTION
`{keras3}` is going to be the permanent name going forward.